### PR TITLE
✨feat : 이메일 인증 토큰 db -> redis & jwt 토큰 수정

### DIFF
--- a/readnspeak/build.gradle
+++ b/readnspeak/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'net.bytebuddy:byte-buddy:1.12.8'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'io.github.cdimascio:java-dotenv:5.2.2'

--- a/readnspeak/src/main/java/com/readnspeak/JwtUtil/JwtAuthenticationFilter.java
+++ b/readnspeak/src/main/java/com/readnspeak/JwtUtil/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = getTokenFromRequest(request);
         
         if (token != null && jwtUtility.validateToken(token, jwtUtility.extractUsername(token))) {
-        	String role = jwtUtility.extractRole(token);
+        	String role = jwtUtility.extractClaims(token).get("role",String.class);
             List <GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
             
             UsernamePasswordAuthenticationToken authentication = 

--- a/readnspeak/src/main/java/com/readnspeak/JwtUtil/JwtUtility.java
+++ b/readnspeak/src/main/java/com/readnspeak/JwtUtil/JwtUtility.java
@@ -11,12 +11,14 @@ import jakarta.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import com.readnspeak.entity.Users;
 
 import java.security.Key;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class JwtUtility {
@@ -27,7 +29,15 @@ public class JwtUtility {
     @Value("${jwt.expiration}")
     private long jwtExpiration;
     
+    @Value("${jwt.refreshExpiration}")
+    private long jwtRefreshExpiration; // Refresh Token의 유효 기간 추가
+    
     private Key key;
+    private final RedisTemplate<String, String> redisTemplate;
+    
+    public JwtUtility(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
     
     @PostConstruct
     public void init() {
@@ -42,7 +52,7 @@ public class JwtUtility {
     public String generateToken(Users user) {
     	
         return Jwts.builder()
-                .setSubject(String.valueOf(user.getUsername())) // 사용자 ID
+                .setSubject(String.valueOf(user.getUser_id())) // 사용자 id
                 .claim("username", user.getUsername()) // 사용자명
                 .claim("role", user.getRole()) // 사용자 역할
                 .setIssuedAt(new Date()) // 토큰 발급 시간
@@ -50,10 +60,38 @@ public class JwtUtility {
                 .signWith(key)
                 .compact(); // 토큰 생성
     }
+    
+    // Refresh Token 생성
+    public String generateRefreshToken(Users user) {
+        String refreshToken = Jwts.builder()
+                .setSubject(String.valueOf(user.getUser_id()))
+                .claim("username", user.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtRefreshExpiration))
+                .signWith(key)
+                .compact();
+
+        // Redis에 Refresh Token 저장 (유효 기간 설정)
+        redisTemplate.opsForValue().set(user.getUsername(), refreshToken, jwtRefreshExpiration, TimeUnit.MILLISECONDS);
+
+        return refreshToken;
+    }
+    
+ // Redis에서 Refresh Token을 가져옴
+    public String getRefreshTokenFromRedis(String username) {
+        return redisTemplate.opsForValue().get(username);
+    }
+
+    // Refresh Token 유효성 검증
+    public boolean validateRefreshToken(String token, String username) {
+        // Redis에서 저장된 Refresh Token을 조회하여 비교
+        String storedToken = getRefreshTokenFromRedis(username);
+        return storedToken != null && storedToken.equals(token);
+    }
 
     // JWT 토큰에서 사용자 정보(username) 추출
     public String extractUsername(String token) {
-        return extractClaims(token).getSubject();
+        return extractClaims(token).get("username",String.class);
     }
 
     // JWT 토큰의 만료일자 확인
@@ -88,5 +126,24 @@ public class JwtUtility {
     // JWT 토큰 검증
     public boolean validateToken(String token, String username) {
         return (username.equals(extractUsername(token)) && !isTokenExpired(token));
+    }
+    
+ // Refresh Token 검증
+    public boolean validateRefreshToken(String token) {
+        return !isTokenExpired(token); // Refresh Token이 만료되지 않았으면 유효한 것으로 판단
+    }
+    
+ // 새로운 Access Token 발급
+    public String refreshAccessToken(String refreshToken, Users user) {
+        if (validateRefreshToken(refreshToken)) {
+            return generateToken(user); // 유효한 Refresh Token이면 새로운 Access Token 생성
+        } else {
+            throw new IllegalArgumentException("Invalid or expired refresh token");
+        }
+    }
+    
+ // Refresh Token 삭제 (로그아웃 시 사용)
+    public void deleteRefreshToken(String username) {
+        redisTemplate.delete(username);
     }
 }

--- a/readnspeak/src/main/java/com/readnspeak/JwtUtil/JwtUtility.java
+++ b/readnspeak/src/main/java/com/readnspeak/JwtUtil/JwtUtility.java
@@ -144,6 +144,13 @@ public class JwtUtility {
     
  // Refresh Token 삭제 (로그아웃 시 사용)
     public void deleteRefreshToken(String username) {
-        redisTemplate.delete(username);
+    	try {
+            redisTemplate.delete(username);
+        } catch (Exception e) {
+            // Redis 연결 문제 등 예외를 처리
+            throw new IllegalStateException("Failed to delete refresh token for user: " + username, e);
+        }
     }
+    
+    
 }

--- a/readnspeak/src/main/java/com/readnspeak/controller/AuthController.java
+++ b/readnspeak/src/main/java/com/readnspeak/controller/AuthController.java
@@ -44,4 +44,6 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or expired refresh token");
         }
     }
+    
+    
 }

--- a/readnspeak/src/main/java/com/readnspeak/controller/AuthController.java
+++ b/readnspeak/src/main/java/com/readnspeak/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.readnspeak.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.readnspeak.JwtUtil.JwtUtility;
+import com.readnspeak.dto.ResponseDto;
+import com.readnspeak.entity.Users;
+import com.readnspeak.repository.UserRepository;
+import com.readnspeak.service.UserService;
+
+@RestController
+public class AuthController {
+
+    private final JwtUtility jwtUtility;
+    private final UserService userService; // 사용자를 조회하는 서비스
+    private final UserRepository userRepository;
+
+    public AuthController(JwtUtility jwtUtility, UserService userService, UserRepository userRepository) {
+        this.jwtUtility = jwtUtility;
+        this.userService = userService;
+		this.userRepository = userRepository;
+    }
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<?> refreshAccessToken(@RequestBody String refreshToken) {
+        // 클라이언트가 보낸 Refresh Token으로 사용자를 식별
+        String username = jwtUtility.extractUsername(refreshToken);
+        Users user = userRepository.findByUsername(username)
+        		.orElseThrow(() -> new IllegalArgumentException("Invalid username"));
+        
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user");
+        }
+        
+        try {
+            // refreshAccessToken 메소드로 새로운 Access Token 발급
+            String newAccessToken = jwtUtility.refreshAccessToken(refreshToken, user);
+            return ResponseEntity.ok(newAccessToken);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or expired refresh token");
+        }
+    }
+}

--- a/readnspeak/src/main/java/com/readnspeak/controller/UserController.java
+++ b/readnspeak/src/main/java/com/readnspeak/controller/UserController.java
@@ -80,9 +80,16 @@ public class UserController {
     }
        
     @PostMapping("/logout")
-    public ResponseEntity<?> logout() {
-        // 클라이언트 측에서 토큰 삭제 유도 (서버는 처리할 필요 없음)
-        return ResponseEntity.ok("Logged out successfully");
+    public ResponseEntity<?> logout(Authentication authentication) {
+    	try {
+            // 로그아웃 처리 및 Refresh Token 삭제
+            userService.logoutdeleterefresh(authentication.getName());
+            return ResponseEntity.ok("Logout successful");
+        } catch (Exception e) {
+            // 그 외의 예외 처리
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("An unexpected error occurred: " + e.getMessage());
+        }
     }
     
     @PutMapping("/profile")

--- a/readnspeak/src/main/java/com/readnspeak/controller/UserController.java
+++ b/readnspeak/src/main/java/com/readnspeak/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.readnspeak.controller;
 
 import com.readnspeak.JwtUtil.JwtUtility;
+import com.readnspeak.dto.LoginDto;
 import com.readnspeak.dto.ResponseDto;
+import com.readnspeak.dto.updateDto;
 import com.readnspeak.entity.EmailVerificationRequest;
 import com.readnspeak.entity.EmailVerificationToken;
 import com.readnspeak.entity.Users;
@@ -10,6 +12,7 @@ import com.readnspeak.service.EmailVerificationService;
 import com.readnspeak.service.UserService;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,13 +67,13 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> loginUser(@RequestBody Users user) {
+    public ResponseEntity<?> loginUser(@RequestBody LoginDto logindto) {
         try {
         	// 사용자 인증
-            String token = userService.authenticateUser(user); // JWT 토큰 생성
+        	Map<String, String> tokens = userService.authenticateUser(logindto); //토큰 생성
             
             // 토큰 반환
-            return ResponseEntity.ok(new ResponseDto(token));  // Return JWT token
+        	return ResponseEntity.ok(new ResponseDto(tokens));  // Return both accessToken and refreshToken
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
         }
@@ -83,10 +86,12 @@ public class UserController {
     }
     
     @PutMapping("/profile")
-    public ResponseEntity<?> updateProfile(@RequestBody Users userDto, Authentication authentication) {
+    public ResponseEntity<?> updateProfile(@RequestBody updateDto userDto, Authentication authentication) {
     	String currentUsername = authentication.getName();
     	Users user = userService.updateUserProfile(currentUsername, userDto);
     	
     	return ResponseEntity.ok("Profile updated successfully");
     }
+    
+    
 }

--- a/readnspeak/src/main/java/com/readnspeak/dto/LoginDto.java
+++ b/readnspeak/src/main/java/com/readnspeak/dto/LoginDto.java
@@ -1,0 +1,19 @@
+package com.readnspeak.dto;
+
+public class LoginDto {
+	private String username;
+	private String password_hash;
+	public String getUsername() {
+		return username;
+	}
+	public void setUsername(String username) {
+		this.username = username;
+	}
+	public String getPassword_hash() {
+		return password_hash;
+	}
+	public void setPassword_hash(String password_hash) {
+		this.password_hash = password_hash;
+	}
+	
+}

--- a/readnspeak/src/main/java/com/readnspeak/dto/ResponseDto.java
+++ b/readnspeak/src/main/java/com/readnspeak/dto/ResponseDto.java
@@ -1,19 +1,30 @@
 package com.readnspeak.dto;
 
+import java.util.Map;
+
 public class ResponseDto {
-	private String token;
-	
-	public ResponseDto(String token) {
-		this.token = token;
-	}
+    private String accessToken;
+    private String refreshToken;
 
-	public String getToken() {
-		return token;
-	}
+    public ResponseDto(Map<String, String> tokens) {
+        this.accessToken = tokens.get("accessToken");
+        this.refreshToken = tokens.get("refreshToken");
+    }
 
-	public void setToken(String token) {
-		this.token = token;
-	}
-	
-	
+    // Getter and Setter methods
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/readnspeak/src/main/java/com/readnspeak/dto/updateDto.java
+++ b/readnspeak/src/main/java/com/readnspeak/dto/updateDto.java
@@ -1,0 +1,27 @@
+package com.readnspeak.dto;
+
+public class updateDto {
+	private String username;
+	private String email;
+	private String password_hash;
+	public String getUsername() {
+		return username;
+	}
+	public void setUsername(String username) {
+		this.username = username;
+	}
+	public String getEmail() {
+		return email;
+	}
+	public void setEmail(String email) {
+		this.email = email;
+	}
+	public String getPassword_hash() {
+		return password_hash;
+	}
+	public void setPassword_hash(String password_hash) {
+		this.password_hash = password_hash;
+	}
+	
+	
+}

--- a/readnspeak/src/main/java/com/readnspeak/service/EmailVerificationService.java
+++ b/readnspeak/src/main/java/com/readnspeak/service/EmailVerificationService.java
@@ -57,4 +57,6 @@ public class EmailVerificationService {
 
         return storedToken.equals(token);
     }
+    
+    
 }

--- a/readnspeak/src/main/java/com/readnspeak/service/EmailVerificationService.java
+++ b/readnspeak/src/main/java/com/readnspeak/service/EmailVerificationService.java
@@ -4,37 +4,33 @@ import com.readnspeak.entity.EmailVerificationToken;
 import com.readnspeak.repository.EmailVerificationTokenRepository;
 import com.readnspeak.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 @Service
 public class EmailVerificationService {
 
-    private final JavaMailSender emailSender;
-    private final EmailVerificationTokenRepository tokenRepository;
-    private final UserRepository userRepository;
+	private final JavaMailSender emailSender;
+    private final StringRedisTemplate redisTemplate;
 
     @Autowired
-    public EmailVerificationService(JavaMailSender emailSender,
-                                    EmailVerificationTokenRepository tokenRepository,
-                                    UserRepository userRepository) {
+    public EmailVerificationService(JavaMailSender emailSender, StringRedisTemplate redisTemplate) {
         this.emailSender = emailSender;
-        this.tokenRepository = tokenRepository;
-        this.userRepository = userRepository;
+        this.redisTemplate = redisTemplate;
     }
 
     // 이메일 인증 토큰 생성 및 발송
     public void sendVerificationEmail(String email) {
-        String token = generateVerificationToken();
-        EmailVerificationToken verificationToken = new EmailVerificationToken();
-        verificationToken.setEmail(email);
-        verificationToken.setToken(token);
-        verificationToken.setExpiryDate(LocalDateTime.now().plusMinutes(15)); // 토큰 만료 시간 설정
-        tokenRepository.save(verificationToken);
+    	String token = generateVerificationToken();
+
+        // Redis에 인증 토큰 저장 (TTL 15분 설정)
+        redisTemplate.opsForValue().set(email, token, 15, TimeUnit.MINUTES);
 
         sendEmail(email, token);
     }
@@ -51,17 +47,14 @@ public class EmailVerificationService {
         message.setText("Your verification code is: " + token);
         emailSender.send(message);
     }
-
-    // 인증 코드 검증
+    
     public boolean verifyToken(String email, String token) {
-        EmailVerificationToken verificationToken = tokenRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("Verification token not found"));
-        
-        if (verificationToken.getExpiryDate().isBefore(LocalDateTime.now())) {
-        	tokenRepository.delete(verificationToken);
-            throw new IllegalArgumentException("Token has expired");
+        String storedToken = redisTemplate.opsForValue().get(email);
+
+        if (storedToken == null) {
+            throw new IllegalArgumentException("Verification token not found or expired");
         }
-        System.out.println(verificationToken.getToken().equals(token));
-        return verificationToken.getToken().equals(token);
+
+        return storedToken.equals(token);
     }
 }

--- a/readnspeak/src/main/java/com/readnspeak/service/UserService.java
+++ b/readnspeak/src/main/java/com/readnspeak/service/UserService.java
@@ -81,5 +81,17 @@ public class UserService {
     	return userRepository.save(existinguser);
     }
     
+    public void logoutdeleterefresh(String username) {
+    	try {
+            jwtUtility.deleteRefreshToken(username);
+        } catch (IllegalStateException e) {
+            // Redis에서 refresh token 삭제 실패 시 예외 처리
+            throw new IllegalStateException("Failed to delete refresh token for user: " + username, e);
+        } catch (Exception e) {
+            // 그 외의 예외 처리
+            throw new RuntimeException("Unexpected error occurred during logout for user: " + username, e);
+        }
+    }
+    
     
 }


### PR DESCRIPTION
#26
이메일 인증 토큰을 db에 저장하는 대신 redis에 저장
jwt 토큰은 accesstoken 외 refreshtoken을 추가 발급 및 redis에 저장하여 accesstoken이 만료되었을 때
refreshtoken을 통해 accesstoken을 재발급하도록 수정